### PR TITLE
Unpin psych

### DIFF
--- a/yaml_normalizer.gemspec
+++ b/yaml_normalizer.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'peach', '~> 0.5'
-  spec.add_dependency 'psych', '~> 2.2'
+  spec.add_dependency 'psych', '>= 2.2'
   spec.add_dependency 'rake', '~> 12.0'
 
   spec.add_development_dependency 'awesome_print'


### PR DESCRIPTION
We are running into a compatibility issue using this gem with another
gem which uses a newer version of psych. This pull request unpins the
psych dependency from `~> 2.2` to `>= 2.2` for compatibility with newer
versions of psych.